### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/GenerateData.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/GenerateData.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/GenerateData.java
@@ -195,7 +195,7 @@ class GenerateData extends GridmixJob {
         try {
           FileInputFormat.addInputPath(job, new Path("ignored"));
         } catch (IOException e) {
-          LOG.error("Error while adding input path ", e);
+          LOG.error("Error while adding input path {}", "ignored", e);
         }
       }
     });


### PR DESCRIPTION
- The following log line <logLine>LOG.error("Error while adding input path ", e);</logLine> evaluated against the provided standards: 1. The log line does include the exception as a parameter.  2. The log line does not include sensitive information. 3. The log message is concise, but it could be more informative by including the input path that caused the error. 4. The log message is for an exception. Due to the violation of standard (3), we would recommend a code change to include the input path in the log message.


Created by Patchwork Technologies.