### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
@@ -202,11 +202,11 @@ public class Gridmix extends Configured implements Tool {
         LOG.info("Changing the permissions for inputPath {}", inputDir);
         shell.run(new String[] {"-chmod","-R","777", inputDir.toString()});
       } catch (Exception e) {
-        LOG.error("Couldnt change the file permissions " , e);
+        LOG.error("Couldn't change file permissions of {} to '777'.", inputDir, e);
         throw new IOException(e);
       }
 
-      LOG.info("Input data generation successful.");
+      LOG.info("Input data generation successful. Generated {} bytes.", genbytes);
     }
 
     return 0;
@@ -295,7 +295,7 @@ public class Gridmix extends Configured implements Tool {
     try {
       Path inputDir = getGridmixInputDataPath(ioPath);
       GridmixJobSubmissionPolicy policy = getJobSubmissionPolicy(conf);
-      LOG.info(" Submission policy is " + policy.name());
+      LOG.info("Submission policy is {}.", policy.name());
       statistics = new Statistics(conf, policy.getPollingInterval(), startFlag);
       monitor = createJobMonitor(statistics, conf);
       int noOfSubmitterThreads = 
@@ -327,7 +327,7 @@ public class Gridmix extends Configured implements Tool {
       monitor.start();
       submitter.start();
     }catch(Exception e) {
-      LOG.error(" Exception at start " ,e);
+      LOG.error("Error encountered while attempting to start threads", e);
       throw new IOException(e);
     }
    }
@@ -388,7 +388,7 @@ public class Gridmix extends Configured implements Tool {
   private int runJob(Configuration conf, String[] argv)
     throws IOException, InterruptedException {
     if (argv.length < 2) {
-      LOG.error("Too few arguments to Gridmix.\n");
+      LOG.error("Too few arguments to Gridmix. Received {} but expected at least 2.", argv.length);
       printUsage(System.err);
       return ARGS_ERROR;
     }
@@ -405,8 +405,7 @@ public class Gridmix extends Configured implements Tool {
         if ("-generate".equals(argv[i])) {
           genbytes = StringUtils.TraditionalBinaryPrefix.string2long(argv[++i]);
           if (genbytes <= 0) {
-            LOG.error("size of input data to be generated specified using "
-                      + "-generate option should be nonnegative.\n");
+            LOG.error("Size of input data to be generated specified using -generate option should be nonnegative. Actual value: {}.", genbytes);
             return ARGS_ERROR;
           }
         } else if ("-users".equals(argv[i])) {
@@ -425,8 +424,7 @@ public class Gridmix extends Configured implements Tool {
           }
         } else {
           LOG.error(userResolver.getClass()
-              + " needs target user list. Use -users option.\n");
-          printUsage(System.err);
+          LOG.error("User resource '{}' provided to {} needs target user list. Use -users option.\n", userRsrc, userResolver.getClass());
           return ARGS_ERROR;
         }
       } else if (userRsrc != null) {
@@ -438,7 +436,7 @@ public class Gridmix extends Configured implements Tool {
     } catch (Exception e) {
       LOG.error(e.toString() + "\n");
       if (LOG.isDebugEnabled()) {
-        e.printStackTrace();
+      LOG.error("Error during Gridmix job setup. Exception: {}. Attempted action: {}, Arguments: {}", e.getClass().getSimpleName(), e.getMessage(), Arrays.toString(argv), e);
       }
 
       printUsage(System.err);
@@ -458,7 +456,7 @@ public class Gridmix extends Configured implements Tool {
       if (!succeeded) {
         LOG.error("Failed creation of <ioPath> directory " + ioPath + "\n");
         return STARTUP_FAILED_ERROR;
-      }
+      }LOG.error("Failed creation of <ioPath> directory " + ioPath + "\n", e);
     }
 
     return start(conf, traceIn, ioPath, genbytes, userResolver);
@@ -529,7 +527,7 @@ public class Gridmix extends Configured implements Tool {
       } catch (Throwable e) {
         LOG.error("Startup failed. " + e.toString() + "\n");
         LOG.debug("Startup failed", e);
-        if (factory != null) factory.abort(); // abort pipeline
+        LOG.error("Startup failed.", e);ne
         exitCode = STARTUP_FAILED_ERROR;
       } finally {
         // signal for factory to start; sets start time
@@ -650,7 +648,7 @@ public class Gridmix extends Configured implements Tool {
     public void run() {
       LOG.info("Exiting...");
       try {
-        killComponent(factory, FAC_SLEEP);   // read no more tasks
+      LOG.info("Exiting main method..."); FAC_SLEEP);   // read no more tasks
         killComponent(submitter, SUB_SLEEP); // submit no more tasks
         killComponent(monitor, MON_SLEEP);   // process remaining jobs here
         killComponent(statistics,MON_SLEEP);
@@ -664,7 +662,7 @@ public class Gridmix extends Configured implements Tool {
         }
         LOG.info("Killing running jobs...");
         for (JobStats stats : remainingJobs) {
-          Job job = stats.getJob();
+        LOG.info("Killing running jobs: {}", remainingJobs.stream().map(s -> s.getJob().getJobID().toString()).collect(Collectors.joining(", ")));
           try {
             if (!job.isComplete()) {
               job.killJob();
@@ -681,10 +679,10 @@ public class Gridmix extends Configured implements Tool {
           } catch (Exception e) {
             LOG.error("Unexpected exception", e);
           }
-        }
+        }LOG.error("Unexpected exception while killing running jobs", e);
         LOG.info("Done.");
       }
-    }
+    }LOG.info("Finished killing remaining jobs.");
 
   }
 


### PR DESCRIPTION
- The following log line <logLine>LOG.error("Couldnt change the file permissions " , e);</logLine> evaluated against the provided standards: 1. The log line includes the exception object, which is good. However, it's recommended to include the 'inputDir' variable in the message to provide more context. 2. The log line does not include sensitive information. 3. The log message is somewhat informative but could be improved. It states that file permissions couldn't be changed, but it doesn't specify which permissions or what the desired permissions were. 4. The log message is for an exception and includes the exception object, but it could be more helpful by including what was attempted (changing file permissions of 'inputDir' to '777'). Due to the violations of standards (1), (3), and (4), we would recommend a code change.
- The following log line <logLine>      LOG.info("Input data generation successful.");</logLine> evaluated against the provided standards: 1. The log line does not include parameters, but it could include the size of the generated data (genbytes) for better context. 2. The log line does not include sensitive information. 3. The log message is concise and informative. 4. The log message is not for an exception. Due to the violation of standard (1), we would recommend a code change to include the size of the generated data in the log message.
- The following log line <logLine>      LOG.info(" Submission policy is " + policy.name());</logLine> evaluated against the provided standards: 1. The log line does include a parameter, policy.name(). 2. The log line does not include sensitive information. 3.  The log message has extra spaces and is missing a space before "is". It should be "Submission policy is ..." 4. The log message is not for an exception. We would recommend a code change to address (3).
- The following log line <logLine>      LOG.error(" Exception at start " ,e);</logLine> evaluated against the provided standards: 1. The log line does include the exception as a parameter. 2. The log line does not include sensitive information. 3. The log message is not concise and informative, it contains a leading space and trailing space around the message.  4. The log message is for an exception, however, it does not include what was attempted. Due to the violation of standard (3) and (4), we would recommend a code change to improve the log message. Possible alternatives would be: <br/> `LOG.error("Error starting threads", e);` <br/> `LOG.error("Error encountered while attempting to start threads", e);`
- The following log line <logLine>      LOG.error("Too few arguments to Gridmix.\n");</logLine> evaluated against the provided standards: 1. The log line does not include any parameters. In this case, it would be beneficial to include the number of arguments received. 2. The log line does not include sensitive information. 3. The log message is concise and informative. 4. The log message is not for an exception, but rather a validation error. However, it could be improved by providing more context, such as the expected number of arguments. Due to the violations of standards (1) and (4), we would recommend a code change to include the number of arguments received and the expected number of arguments.
- The following log line <logLine>            LOG.error("size of input data to be generated specified using "\n                      + "-generate option should be nonnegative.\n");</logLine> evaluated against the provided standards: 1. The log line does not include the size of the input data, which would be helpful in diagnosing the issue. 2. The log line does not include sensitive information. 3. The log message is somewhat informative, but could be improved by including the actual value that was provided. 4. The log message is for an exception, but it does not include the cause of the exception. We recommend including the input data size variable in the log message.
- The following log line <logLine>LOG.error(userResolver.getClass()
              + " needs target user list. Use -users option.\n");</logLine> evaluated against the provided standards: 1. The log line does not include a parameter. In this case we could include the userRsrc variable to indicate which resource was being used. 2. The log line does not include sensitive information. 3. The log message is concise and informative. 4. The log message is not for an exception. Due to the violation of standard (1), we would recommend a code change to include the 'userRsrc' variable in the log message.
- The following log line <logLine>LOG.error(e.toString() + "\n");</logLine> evaluated against the provided standards: 1. The log line does not include parameters beyond the exception message. However, it's using a generic 'e' for the exception, making it difficult to trace back which specific error occurred without the stack trace. 2. The log line does not include sensitive information. 3. The log message is not concise nor informative. It only provides the exception message without any context. 4. The log message is for an exception. However, it only includes a generic 'e' and its string representation, lacking details about what was attempted, the specific error, and its cause. The stack trace is only printed if debug logging is enabled, which might not always be the case. Due to the violations of standards (1), (3), and (4), we would recommend a code change to include more context and details in the log message.
- The following log line <logLine>LOG.error("Failed creation of <ioPath> directory " + ioPath + "\n");</logLine> evaluated against the provided standards: 1. The log line does include the parameter `ioPath`. 2. The log line does not include sensitive information. 3. The log message is concise and informative. 4. While the log message is for an exception, the exception itself is not included in the message. The exception contains the reason for failure, which would be helpful to include in the log. Due to the violation of standard (4), we would recommend a code change to include the exception in the log message.
- The following log line <logLine>LOG.error("Startup failed. " + e.toString() + "\n");</logLine> evaluated against the provided standards: 1. The log line does not include parameters, but it may not be possible in this context. 2. The log line does not include sensitive information. 3. The log message is concise and informative. 4. The log message is for an exception, it includes what was attempted (Startup), the error (e.toString()), and the cause (e). However, using e.toString() to log the error message is not ideal as it only provides the exception class and message, without the stack trace. It's better to use a logger method that accepts a Throwable as a parameter to ensure the stack trace is logged. The log line conforms to most of the standards, but there is room for improvement in how the exception is logged.
- The following log line <logLine>      LOG.info("Exiting...");</logLine> evaluated against the provided standards: 1. The log line does not include a parameter, and there are no parameters to include given the context. 2. The log line does not include sensitive information. 3. The log message is concise, but not informative. It would be helpful to know what is exiting. 4. The log message is not for an exception. Due to the violation of standard (3), we would recommend a code change to make the log message more informative.
- The following log line <logLine>LOG.info("Killing running jobs...");</logLine> evaluated against the provided standards: 1. The log line does not include any parameters. However, it may not be possible to include parameters in this case as it's unclear what is being killed. 2. The log line does not include sensitive information. 3. The log message is concise and informative. 4. The log message is not for an exception. We would recommend a code change to include more information about what jobs are being killed, if possible.
- The following log line <logLine>LOG.error("Unexpected exception", e);</logLine> evaluated against the provided standards: 1. The log line includes the exception as a parameter. 2. The log line does not include sensitive information. 3. The log message is not concise and informative. It should include context for what was attempted. 4. The log message is for an exception, but does not include context about what was attempted. Due to the violation of standards (3) and (4), we would recommend a code change to include more context in the log message.
- The following log line <logLine>LOG.info("Done.");</logLine> evaluated against the provided standards: 1. The log line does not include a parameter, and there are no parameters to include given the context. 2. The log line does not include sensitive information. 3. The log message is not concise and informative. It's unclear what operation is "Done."  4. The log message is not for an exception. Due to the violation of standard (3), we would recommend a code change to make the log message more descriptive.


Created by Patchwork Technologies.