### PR TITLE
Modifying log contents in hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/WasbRemoteCallHelper.java

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/WasbRemoteCallHelper.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/WasbRemoteCallHelper.java
@@ -282,11 +282,11 @@ public class WasbRemoteCallHelper {
         return;
       }
     } catch (InterruptedIOException e) {
-      LOG.warn(e.getMessage(), e);
+      LOG.warn("Interrupted while waiting to retry connection", e);
       Thread.currentThread().interrupt();
       return;
     } catch (Exception e) {
-      LOG.warn("Original exception is ", ioe);
+      LOG.warn("Original exception {} while making remote call to {} during retry attempt.", ioe.getMessage(), url, ioe);
       throw new WasbRemoteCallException(e.getMessage(), e);
     }
     LOG.debug("Not retrying anymore, already retried the urls {} time(s)",


### PR DESCRIPTION
- The following log line <logLine>      LOG.warn(e.getMessage(), e);</logLine> evaluated against the provided standards: 1. The log line includes the exception as a parameter, which is good. 2. The log line does not include sensitive information. 3. The log message is not concise and informative. It only includes the exception message, without any context. 4. The log message is for an exception, but it does not include what was attempted.  Due to the violation of standards (3) and (4), we would recommend a code change to include more context in the log message, such as what operation was being attempted when the InterruptedIOException occurred.
- The following log line <logLine>LOG.warn("Original exception is ", ioe);</logLine> evaluated against the provided standards: 1. The log line does include the exception as a parameter. 2. The log line does not include sensitive information. 3. The log message is not concise and informative. It should include more context or details from the exception itself. 4. While this is an exception, the message is not informative. What was attempted? What was the cause?  Due to the violation of standards (3) and (4), we would recommend a code change to improve the log message.


Created by Patchwork Technologies.