### PR TITLE
Modifying log contents in hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/security/JsonUtils.java

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/security/JsonUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/security/JsonUtils.java
@@ -43,8 +43,7 @@ public final class JsonUtils {
       LOG.debug("JSON Parsing exception: {} while parsing {}", e.getMessage(),
           jsonString);
       if (jsonString.toLowerCase(Locale.ENGLISH).contains("server error")) {
-        LOG.error(
-            "Internal Server Error was encountered while making a request");
+        LOG.error("Internal Server Error encountered while making a request with JSON: {}", jsonString, e);
       }
       throw new IOException("JSON Parsing Error: " + e.getMessage(), e);
     }


### PR DESCRIPTION
- The following log line <logLine>        LOG.error(
            "Internal Server Error was encountered while making a request");</logLine> evaluated against the provided standards: 1. The log line does not include any parameters. In this case, it would be beneficial to include the `jsonString` variable as a parameter to provide context about the JSON string that caused the error. 2. The log line does not include sensitive information. 3. The log message is concise and informative, but lacks context. 4. While the log message is for an exception, it does not include the exception message or stack trace. Due to the violations of standards (1) and (4), we would recommend a code change to include the `jsonString` variable and the exception message.


Created by Patchwork Technologies.