### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobMonitor.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobMonitor.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobMonitor.java
@@ -97,7 +97,7 @@ class JobMonitor implements Gridmix.Component<JobStats> {
    */
   public void submissionFailed(JobStats job) {
     String jobID = job.getJob().getConfiguration().get(Gridmix.ORIGINAL_JOB_ID);
-    LOG.info("Job submission failed notification for job " + jobID);
+    LOG.info("Job submission failed notification for job {}. Reason: {}", jobID, job.getStatus().getFailureInfo() != null ? job.getStatus().getFailureInfo().getMessage() : "Unknown");
     synchronized (statistics) {
       this.statistics.add(job);
     }
@@ -107,14 +107,14 @@ class JobMonitor implements Gridmix.Component<JobStats> {
    * Temporary hook for recording job success.
    */
   protected void onSuccess(Job job) {
-    LOG.info(job.getJobName() + " (" + job.getJobID() + ")" + " success");
+    LOG.info("{0} ({1}) success", job.getJobName(), job.getJobID());
   }
 
   /**
    * Temporary hook for recording job failure.
    */
   protected void onFailure(Job job) {
-    LOG.info(job.getJobName() + " (" + job.getJobID() + ")" + " failure");
+    LOG.info("Job {} ({}) failed: {}", job.getJobName(), job.getJobID(), job.getError());
   }
 
   /**
@@ -206,7 +206,7 @@ class JobMonitor implements Gridmix.Component<JobStats> {
                 synchronized (mJobs) {
                   if (!mJobs.offer(jobStats)) {
                     LOG.error("Lost job " + (null == job.getJobName()
-                         ? "<unknown>" : job.getJobName())); // should never
+                         ? "<unknown>" : job.getJobName()) + " due to job queue being full");// should never
                                                              // happen
                   }
                 }


### PR DESCRIPTION
- The following log line <logLine>    LOG.info("Job submission failed notification for job " + jobID);</logLine> evaluated against the provided standards: 1. The log line does include the job ID as a parameter. 2. The log line does not include sensitive information. 3. The log message is concise and informative. 4. While this log message is related to a failed job submission, it doesn't explicitly mention an error or a cause. However, given the context of the method name 'submissionFailed', it can be inferred that an error occurred. Adding more context about the failure reason would enhance the log's usefulness.  Overall, the log line mostly conforms to the standards.  We would recommend adding more context about why the submission failed.
- The following log line <logLine>    LOG.info(job.getJobName() + " (" + job.getJobID() + ")" + " success");</logLine> evaluated against the provided standards: 1. The log line does include parameters job.getJobName() and job.getJobID(). 2. The log line does not include sensitive information. 3. The log message could be more concise by using string formatting: LOG.info("{} ({}) success", job.getJobName(), job.getJobID());  4. The log message is not for an exception. Due to the violation of standard (3), we would recommend a code change to make the log line more concise.
- The following log line <logLine>    LOG.info(job.getJobName() + " (" + job.getJobID() + ")" + " failure");</logLine> evaluated against the provided standards: 1. The log line does include parameters for job name and job ID. 2. The log line does not include sensitive information. 3. The log message could be made more concise and informative by removing the unnecessary string concatenations. 4. The log message is for an exception but does not include the error or the cause. We recommend including contextual information about the failure, such as the error message or stack trace, if available.
- The following log line <logLine>LOG.error("Lost job " + (null == job.getJobName()
                         ? "<unknown>" : job.getJobName())); // should never</logLine> evaluated against the provided standards: 1. The log line does include the job name. 2. The log line does not include sensitive information. 3. The log message is concise and informative. 4. The log message is for an exception, it does log "Lost job", however, it does not include the cause. The log line does not conform to all standards and requires a code change to include the cause of the error.


Created by Patchwork Technologies.