### PR TITLE
Modifying log contents in hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileSystem.java

### DIFF
--- a/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileSystem.java
+++ b/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileSystem.java
@@ -757,7 +757,7 @@ public class AliyunOSSFileSystem extends FileSystem {
     try {
       copyFileContext.awaitAllFinish(copiesToFinish);
     } catch (InterruptedException e) {
-      LOG.warn("interrupted when wait copies to finish");
+      LOG.warn("interrupted when wait copies to finish from {} to {}", srcPath, dstPath, e);
     } finally {
       copyFileContext.unlock();
     }


### PR DESCRIPTION
- The following log line <logLine>      LOG.warn("interrupted when wait copies to finish");</logLine> evaluated against the provided standards: 1. The log line does not include a parameter, and it would be helpful to include the srcPath and dstPath variables to provide context. 2. The log line does not include sensitive information. 3. The log message is concise and informative. 4. While this log is for an exception, it's missing the exception itself. It only logs the message, but including the exception would be more helpful for debugging. Due to the violations of standards (1) and (4), we would recommend a code change to include the 'srcPath', 'dstPath', and the exception 'e' in the log message.


Created by Patchwork Technologies.