### PR TITLE
Modifying log contents in hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileSystemStore.java

### DIFF
--- a/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileSystemStore.java
+++ b/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileSystemStore.java
@@ -534,8 +534,7 @@ public class AliyunOSSFileSystemStore {
       statistics.incrementReadOps(1);
       return in;
     } catch (OSSException | ClientException e) {
-      LOG.error("Exception thrown when store retrieves key: "
-              + key + ", exception: " + e);
+      LOG.error("Exception thrown when store retrieves key: " + key + ", byteStart: " + byteStart + ", byteEnd: " + byteEnd + ", exception: " + e);
       return null;
     }
   }


### PR DESCRIPTION
- The following log line <logLine>      LOG.error("Exception thrown when store retrieves key: "              + key + ", exception: " + e);</logLine> evaluated against the provided standards: 1. The log line includes the key which is good. It could also include the byteStart and byteEnd parameters for additional context. 2. The log line does not include sensitive information. 3. The log message is concise and informative. 4. The log message is for an exception and includes what was attempted (retrieve key), the error (exception), and the cause (e). We would recommend including the additional parameters for more context.


Created by Patchwork Technologies.