### PR TITLE
Modifying log contents in hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java

### DIFF
--- a/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
+++ b/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
@@ -308,8 +308,7 @@ public class HadoopArchiveLogs implements Tool {
             " specified -> recreating Working Dir");
         fs.delete(workingDir, true);
       } else {
-        LOG.info("Existing Working Dir detected: -" + FORCE_OPTION +
-            " not specified -> exiting");
+        LOG.info("Existing Working Dir detected: {} - {} not specified -> exiting prepareWorkingDir", workingDir, FORCE_OPTION);
         return false;
       }
     }


### PR DESCRIPTION
- The following log line <logLine>        LOG.info("Existing Working Dir detected: -" + FORCE_OPTION +             " not specified -> exiting");</logLine> evaluated against the provided standards: 1. The log line does not include any parameters. However, it would be helpful to include the 'workingDir' variable to provide more context. 2. The log line does not include sensitive information. 3. The log message is somewhat informative but could be improved. It states that an existing working directory was detected and that the FORCE_OPTION is not specified, leading to an exit. However, it doesn't explicitly mention what is exiting (e.g., the function, the script, etc.). 4. The log message is not for an exception. Due to the violations of standards (1) and (3), we would recommend a code change to include the 'workingDir' variable and to clarify what is exiting.


Created by Patchwork Technologies.