### PR TITLE
Modifying log contents in hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogsRunner.java

### DIFF
--- a/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogsRunner.java
+++ b/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogsRunner.java
@@ -171,7 +171,7 @@ public class HadoopArchiveLogsRunner implements Tool {
       Path harDest = new Path(remoteAppLogDir, harName);
       LOG.info("Moving har to original location");
       fs.rename(harPath, harDest);
-      LOG.info("Deleting original logs");
+      LOG.info("Deleting original logs from {}", remoteAppLogDir);
       for (FileStatus original : fs.listStatus(new Path(remoteAppLogDir),
           new PathFilter() {
             @Override


### PR DESCRIPTION
- The following log line <logLine>      LOG.info("Deleting original logs");</logLine> evaluated against the provided standards: 1. The log line does not include a parameter. It could include the directory from which the logs are being deleted (remoteAppLogDir). 2. The log line does not include sensitive information. 3. The log message is concise and informative. 4. The log message is not for an exception. Due to the violation of standard (1), we would recommend a code change to include the 'remoteAppLogDir' variable in the log message.


Created by Patchwork Technologies.