### PR TITLE
Modifying log contents in hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSInputStream.java

### DIFF
--- a/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSInputStream.java
+++ b/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSInputStream.java
@@ -167,7 +167,7 @@ public class AliyunOSSInputStream extends FSInputStream {
         this.buffer = readBuffer.getBuffer();
       }
     } catch (InterruptedException e) {
-      LOG.warn("interrupted when wait a read buffer");
+      LOG.warn("interrupted while waiting for read buffer: {}. This might lead to performance degradation.", readBuffer);
     } finally {
       readBuffer.unlock();
     }


### PR DESCRIPTION
- The following log line <logLine>LOG.warn("interrupted when wait a read buffer");</logLine> evaluated against the provided standards: 1. The log line does not include a parameter. However, it could include the 'readBuffer' object to provide more context. 2. The log line does not include sensitive information. 3. The log message is concise, but not entirely informative. It states that an interruption occurred while waiting for a read buffer, but it doesn't explain why the interruption is a warning-worthy event. 4. The log message is for an exception. It captures the fact that an InterruptedException occurred, but it doesn't provide details about the attempted operation (waiting for a read buffer), the error (interruption), and the potential cause. Due to the violations of standards (1), (3), and (4), we would recommend a code change to include the 'readBuffer' object, explain why the interruption is a warning, and provide more context about the exception.


Created by Patchwork Technologies.