### PR TITLE
Modifying log contents in hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSUtils.java

### DIFF
--- a/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSUtils.java
+++ b/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSUtils.java
@@ -256,8 +256,7 @@ final public class AliyunOSSUtils {
           property, partSize);
       partSize = MULTIPART_MIN_SIZE;
     } else if (partSize > Integer.MAX_VALUE) {
-      LOG.warn("oss: {} capped to ~2.14GB(maximum allowed size with " +
-          "current output mechanism)", MULTIPART_UPLOAD_PART_SIZE_KEY);
+      LOG.warn("oss: {} capped to {}GB (maximum allowed size with current output mechanism)", MULTIPART_UPLOAD_PART_SIZE_KEY, Integer.MAX_VALUE / (1024.0 * 1024.0 * 1024.0));
       partSize = Integer.MAX_VALUE;
     }
     return partSize;


### PR DESCRIPTION
- The following log line <logLine>      LOG.warn("oss: {} capped to ~2.14GB(maximum allowed size with " +
          "current output mechanism)", MULTIPART_UPLOAD_PART_SIZE_KEY);</logLine> evaluated against the provided standards: 1. The log line does include the parameter 'MULTIPART_UPLOAD_PART_SIZE_KEY'. 2. The log line does not include sensitive information. 3. The log message is arguably not concise.  Including the actual size in GB as opposed to ~2.14GB would be more informative. 4. The log message is not for an exception. We would recommend a code change to improve standard (3).


Created by Patchwork Technologies.