### PR TITLE
Modifying log contents in hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileReaderTask.java

### DIFF
--- a/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileReaderTask.java
+++ b/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileReaderTask.java
@@ -90,7 +90,7 @@ public class AliyunOSSFileReaderTask implements Runnable {
             }
           } catch (Exception ex) {
             //FAIL
-            LOG.warn("Exception thrown when call shouldRetry, exception " + ex);
+            LOG.warn("Exception thrown when call shouldRetry for retry policy {} and original exception {}, current exception {}", retryPolicy, e, ex);
             break;
           }
         }


### PR DESCRIPTION
- The following log line <logLine>LOG.warn("Exception thrown when call shouldRetry, exception " + ex);</logLine> evaluated against the provided standards: 1. The log line does include the exception as a parameter. 2. The log line does not include sensitive information. 3. The log message is concise, but not as informative as it could be. 4. The log message is for an exception, but is missing context such as what retry policy was being used and what the original exception was. Due to the violation of standards (3) and (4), we would recommend a code change to include more context in the log message.


Created by Patchwork Technologies.