### PR TITLE
Modifying log contents in hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSInputStream.java

### DIFF
--- a/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSInputStream.java
+++ b/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSInputStream.java
@@ -167,7 +167,7 @@ public class AliyunOSSInputStream extends FSInputStream {
         this.buffer = readBuffer.getBuffer();
       }
     } catch (InterruptedException e) {
-      LOG.warn("interrupted when wait a read buffer");
+      LOG.warn("Interrupted while waiting for a read buffer", e);
     } finally {
       readBuffer.unlock();
     }


### PR DESCRIPTION
- The following log line <logLine>      LOG.warn("interrupted when wait a read buffer");</logLine> evaluated against the provided standards: 1. The log line does not include any parameters. In this case we are logging an exception, and the exception object 'e' should be included as a parameter. 2. The log line does not include sensitive information. 3. The log message is concise, but not informative. It does not include what was attempted. 4. The log message is for an exception, but does not include what was attempted, and the cause. Due to the violations of standards (1), (3), and (4), we would recommend a code change to include the exception object 'e', what was attempted, and the cause.


Created by Patchwork Technologies.