### PR TITLE
Modifying log contents in hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java

### DIFF
--- a/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
+++ b/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
@@ -149,7 +149,7 @@ public class HadoopArchiveLogs implements Tool {
     List<LogAggregationFileController> fileControllers = factory
         .getConfiguredLogAggregationFileControllerList();
     if (fileControllers == null || fileControllers.isEmpty()) {
-      LOG.info("Can not find any valid fileControllers.");
+      LOG.info("Can not find any valid fileControllers. Configured file controllers: {}", YarnConfiguration.LOG_AGGREGATION_FILE_FORMATS);
       if (verbose) {
         LOG.info("The configurated fileControllers:"
             + YarnConfiguration.LOG_AGGREGATION_FILE_FORMATS);


### PR DESCRIPTION
- The following log line <logLine>      LOG.info("Can not find any valid fileControllers.");</logLine> evaluated against the provided standards: 1. The log line does not include a parameter. It could include the configuration parameter YarnConfiguration.LOG_AGGREGATION_FILE_FORMATS to provide more context. 2. The log line does not include sensitive information. 3. The log message is concise and informative. 4. The log message is not for an exception. Due to the violation of standard (1), we would recommend a code change to include the configuration parameter in the log message.


Created by Patchwork Technologies.