### PR TITLE
Modifying log contents in hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java

### DIFF
--- a/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
+++ b/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
@@ -165,8 +165,7 @@ public class HadoopArchiveLogs implements Tool {
         String suffix = fileController.getRemoteRootLogDirSuffix();
         Path workingDir = new Path(remoteRootLogDir, "archive-logs-work");
         if (verbose) {
-          LOG.info("LogAggregationFileController:" + fileController
-              .getClass().getName());
+          LOG.info("LogAggregationFileController: {}", fileController.getClass().getName());
           LOG.info("Remote Log Dir Root: " + remoteRootLogDir);
           LOG.info("Log Suffix: " + suffix);
           LOG.info("Working Dir: " + workingDir);


### PR DESCRIPTION
- The following log line <logLine>          LOG.info("LogAggregationFileController:" + fileController
              .getClass().getName());</logLine> evaluated against the provided standards: 1. The log line does not include a parameter. It should at least include the fileController as a parameter so that it's clear which controller is being logged. 2. The log line does not include sensitive information. 3. The log message is not concise, it could be simplified to "LogAggregationFileController: {}" and include the fileController as a parameter. 4. The log message is not for an exception. Due to the violations of standards (1) and (3), we would recommend a code change.


Created by Patchwork Technologies.