### PR TITLE
Modifying log contents in hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java

### DIFF
--- a/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
+++ b/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
@@ -266,9 +266,7 @@ public class HadoopArchiveLogs implements Tool {
         maxEligible = Integer.parseInt(
             commandLine.getOptionValue(MAX_ELIGIBLE_APPS_OPTION));
         if (maxEligible == 0) {
-          LOG.info("Setting " + MAX_ELIGIBLE_APPS_OPTION + " to 0 accomplishes "
-              + "nothing. Please either set it to a negative value "
-              + "(default, all) or a more reasonable value.");
+          LOG.info("Setting {} to 0 has no effect. Use a negative value for default or a value greater than 0.", MAX_ELIGIBLE_APPS_OPTION);
           System.exit(0);
         }
       }


### PR DESCRIPTION
- The following log line <logLine>          LOG.info("Setting " + MAX_ELIGIBLE_APPS_OPTION + " to 0 accomplishes "\n              + "nothing. Please either set it to a negative value "\n              + "(default, all) or a more reasonable value.");</logLine> evaluated against the provided standards: 1. The log line does include the parameter 'MAX_ELIGIBLE_APPS_OPTION'. 2. The log line does not include sensitive information. 3. The log message is not concise. The message could be reduced to 'Setting MAX_ELIGIBLE_APPS_OPTION to 0 has no effect. Use a negative value for default or a value greater than 0.' 4. The log message is not for an exception. Due to the violation of standard (3), we would recommend a code change to make the log message more concise.


Created by Patchwork Technologies.