### PR TITLE
Modifying log contents in hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileSystemStore.java

### DIFF
--- a/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileSystemStore.java
+++ b/hadoop-tools/hadoop-aliyun/src/main/java/org/apache/hadoop/fs/aliyun/oss/AliyunOSSFileSystemStore.java
@@ -121,7 +121,7 @@ public class AliyunOSSFileSystemStore {
         clientConf.setProxyPort(proxyPort);
       } else {
         if (secureConnections) {
-          LOG.warn("Proxy host set without port. Using HTTPS default 443");
+          LOG.warn("Proxy host {} set without port. Using HTTPS default 443", proxyHost);
           clientConf.setProxyPort(443);
         } else {
           LOG.warn("Proxy host set without port. Using HTTP default 80");


### PR DESCRIPTION
- The following log line <logLine>          LOG.warn("Proxy host set without port. Using HTTPS default 443");</logLine> evaluated against the provided standards: 1. The log line does not include any parameters. In this case, it would be beneficial to include the proxy host that was set. 2. The log line does not include sensitive information. 3. The log message is concise and informative. 4. The log message is not for an exception. Due to the violation of standard (1), we would recommend a code change to include the proxy host variable in the log message.


Created by Patchwork Technologies.