### PR TITLE
Modifying log contents in hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java

### DIFF
--- a/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
+++ b/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
@@ -182,7 +182,14 @@ public class HadoopArchiveLogs implements Tool {
       }
       checkMaxEligible();
       if (workingDirs.isEmpty() || eligibleApplications.isEmpty()) {
-        LOG.info("No eligible applications to process");
+        StringBuilder eligibilityCriteria = new StringBuilder();
+if (workingDirs.isEmpty()) {
+  eligibilityCriteria.append("No working directories found. ");
+}
+if (eligibleApplications.isEmpty()) {
+  eligibilityCriteria.append("No eligible applications found. ");
+}
+LOG.info("No eligible applications to process. Reasons: " + eligibilityCriteria.toString());
         return 0;
       }
       for (Path workingDir : workingDirs) {


### PR DESCRIPTION
- The following log line <logLine>LOG.info("No eligible applications to process");</logLine> evaluated against the provided standards: 1. The log line does not include a parameter, and it would be more useful if it included the criteria used to determine eligibility. 2. The log line does not include sensitive information. 3. The log message is concise and informative. 4. The log message is not for an exception. Due to the violation of standard (1), we would recommend a code change to include the criteria used to determine application eligibility.


Created by Patchwork Technologies.