### PR TITLE
Modifying log contents in hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java

### DIFF
--- a/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
+++ b/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
@@ -197,7 +197,7 @@ public class HadoopArchiveLogs implements Tool {
       for (AppInfo app : eligibleApplications) {
         sb.append("\n\t").append(app.getAppId());
       }
-      LOG.info(sb.toString());
+      LOG.info("Will process the following applications: \n{}", sb.toString());
       File localScript = File.createTempFile("hadoop-archive-logs-", ".sh");
       generateScript(localScript);
 


### PR DESCRIPTION
- The following log line <logLine>      LOG.info(sb.toString());</logLine> evaluated against the provided standards: 1. The log line does not include parameters. However, it is using a StringBuilder, 'sb', which may contain important contextual information. It would be better to include the content of the StringBuilder as a parameter for clarity. 2. The log line does not include sensitive information. 3. The log message's clarity depends on the content of the StringBuilder. It might not be concise and informative if the StringBuilder content is not well-formatted or meaningful. 4. The log message is not for an exception. Due to the violation of standard (1) and potential violation of standard (3), we would recommend a code change to include the content of the StringBuilder as a parameter in the log message.


Created by Patchwork Technologies.