### PR TITLE
Modifying log contents in hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java

### DIFF
--- a/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
+++ b/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
@@ -304,8 +304,7 @@ public class HadoopArchiveLogs implements Tool {
   boolean prepareWorkingDir(FileSystem fs, Path workingDir) throws IOException {
     if (fs.exists(workingDir)) {
       if (force) {
-        LOG.info("Existing Working Dir detected: -" + FORCE_OPTION +
-            " specified -> recreating Working Dir");
+        LOG.info("Existing Working Dir detected: {} -" + FORCE_OPTION + " specified -> recreating Working Dir", workingDir);
         fs.delete(workingDir, true);
       } else {
         LOG.info("Existing Working Dir detected: -" + FORCE_OPTION +


### PR DESCRIPTION
- The following log line <logLine>        LOG.info("Existing Working Dir detected: -" + FORCE_OPTION +             " specified -> recreating Working Dir");</logLine> evaluated against the provided standards: 1. The log line does not include any parameters. It could include the variable 'workingDir' to add more context to the log message. 2. The log line does not include sensitive information. 3. The log message is concise and informative. 4. The log message is not for an exception. Due to the violation of standard (1), we would recommend a code change to include the 'workingDir' variable in the log message.


Created by Patchwork Technologies.