### PR TITLE
Modifying log contents in hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java

### DIFF
--- a/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
+++ b/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogs.java
@@ -308,8 +308,7 @@ public class HadoopArchiveLogs implements Tool {
             " specified -> recreating Working Dir");
         fs.delete(workingDir, true);
       } else {
-        LOG.info("Existing Working Dir detected: -" + FORCE_OPTION +
-            " not specified -> exiting");
+        LOG.info("Existing Working Dir detected: {} -" + FORCE_OPTION + " not specified -> exiting", workingDir);
         return false;
       }
     }


### PR DESCRIPTION
- The following log line <logLine>        LOG.info("Existing Working Dir detected: -" + FORCE_OPTION +             " not specified -> exiting");</logLine> evaluated against the provided standards: 1. The log line does not include any parameters. In this case, it would be beneficial to include the path of the working directory (`workingDir`) in the log message. 2. The log line does not include sensitive information. 3. The log message is concise and informative. 4. The log message is not for an exception. Due to the violation of standard (1), we would recommend a code change to include the 'workingDir' variable in the log message.


Created by Patchwork Technologies.