### PR TITLE
Modifying log contents in hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogsRunner.java

### DIFF
--- a/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogsRunner.java
+++ b/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogsRunner.java
@@ -153,7 +153,7 @@ public class HadoopArchiveLogsRunner implements Tool {
     LOG.info(sb.toString());
     int exitCode = hadoopArchives.run(haArgs);
     if (exitCode != 0) {
-      LOG.warn("Failed to create archives for " + appId);
+      LOG.warn("Failed to create archives for " + appId + ". Hadoop archive exit code: " + exitCode);
       return -1;
     }
 


### PR DESCRIPTION
- The following log line <logLine>      LOG.warn("Failed to create archives for " + appId);</logLine> evaluated against the provided standards: 1. The log line does include the parameter `appId`. 2. The log line does not include sensitive information. 3. The log message is concise and informative. 4. The log message does not include the cause of the error. It only states the action that failed. We would recommend including the root cause of why the archive creation failed. The log line does not conform to all the standards and requires a code change.


Created by Patchwork Technologies.