### PR TITLE
Modifying log contents in hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogsRunner.java

### DIFF
--- a/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogsRunner.java
+++ b/hadoop-tools/hadoop-archive-logs/src/main/java/org/apache/hadoop/tools/HadoopArchiveLogsRunner.java
@@ -169,7 +169,7 @@ public class HadoopArchiveLogsRunner implements Tool {
         return -1;
       }
       Path harDest = new Path(remoteAppLogDir, harName);
-      LOG.info("Moving har to original location");
+      LOG.info("Moving har from {} to {}", harPath, harDest);
       fs.rename(harPath, harDest);
       LOG.info("Deleting original logs");
       for (FileStatus original : fs.listStatus(new Path(remoteAppLogDir),


### PR DESCRIPTION
- The following log line <logLine>      LOG.info("Moving har to original location");</logLine> evaluated against the provided standards: 1. The log line does not include any parameters. It could include the source and destination of the har file being moved. 2. The log line does not include sensitive information. 3. The log message is concise and informative. 4. The log message is not for an exception. Due to the violation of standard (1), we would recommend a code change to include the source and destination paths in the log message.


Created by Patchwork Technologies.