### PR TITLE
Modifying log contents in hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SecureStorageInterfaceImpl.java

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SecureStorageInterfaceImpl.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SecureStorageInterfaceImpl.java
@@ -124,7 +124,7 @@ public class SecureStorageInterfaceImpl extends StorageInterface {
   public void createBlobClient(URI baseUri) {
     String errorMsg = "createBlobClient is an invalid operation in "
         + "SAS Key Mode";
-    LOG.error(errorMsg);
+    LOG.error("createBlobClient is an invalid operation in SAS Key Mode for baseUri: {}", baseUri);
     throw new UnsupportedOperationException(errorMsg);
   }
 


### PR DESCRIPTION
- The log message would be more informative if it included the 'baseUri' to provide context about the specific operation that failed.


Created by Patchwork Technologies.