### PR TITLE
Modifying log contents in hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SecureStorageInterfaceImpl.java

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SecureStorageInterfaceImpl.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SecureStorageInterfaceImpl.java
@@ -132,7 +132,7 @@ public class SecureStorageInterfaceImpl extends StorageInterface {
   public void createBlobClient(URI baseUri, StorageCredentials credentials) {
     String errorMsg = "createBlobClient is an invalid operation in SAS "
         + "Key Mode";
-    LOG.error(errorMsg);
+    LOG.error("createBlobClient is an invalid operation in SAS Key Mode for baseUri: {}", baseUri);
     throw new UnsupportedOperationException(errorMsg);
   }
 


### PR DESCRIPTION
- The 'baseUri' parameter should be added to the log message to provide context. The 'credentials' parameter should not be added due to security concerns. 


Created by Patchwork Technologies.