### PR TITLE
Modifying log contents in hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SecureStorageInterfaceImpl.java

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SecureStorageInterfaceImpl.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SecureStorageInterfaceImpl.java
@@ -250,7 +250,7 @@ public class SecureStorageInterfaceImpl extends StorageInterface {
         String errorMsg = "Encountered SASKeyGeneration exception while "
             + "generating SAS Key for relativePath : " + relativePath
             + " inside container : " + getName()  + " Storage account : " + storageAccount;
-        LOG.error(errorMsg);
+        LOG.error(errorMsg, sasEx);
         throw new StorageException(SAS_ERROR_CODE, errorMsg, sasEx);
       }
     }


### PR DESCRIPTION
- The code should be changed to include the 'sasEx' parameter in the log message to provide more context about the error.


Created by Patchwork Technologies.