### PR TITLE
Modifying log contents in hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SecureStorageInterfaceImpl.java

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SecureStorageInterfaceImpl.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SecureStorageInterfaceImpl.java
@@ -271,7 +271,7 @@ public class SecureStorageInterfaceImpl extends StorageInterface {
             + "generating SAS Key for relativePath : " + relativePath
             + " inside container : " + getName()
             + " Storage account : " + storageAccount;
-        LOG.error(errorMsg);
+        LOG.error(errorMsg, sasEx);
         throw new StorageException(SAS_ERROR_CODE, errorMsg, sasEx);
       }
     }


### PR DESCRIPTION
- The 'sasEx' should be included in the log message to provide more context about the error. The other parameters are already included in the message or are not necessary.


Created by Patchwork Technologies.