### PR TITLE
Modifying log contents in hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SelfRenewingLease.java

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SelfRenewingLease.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SelfRenewingLease.java
@@ -133,8 +133,7 @@ public class SelfRenewingLease {
       } else {
 
         // This error is not anticipated, so re-throw it.
-        LOG.warn("Unanticipated exception when trying to free lease " + leaseID
-            + " on " +  blobWrapper.getStorageUri());
+        LOG.warn("Unanticipated exception when trying to free lease {} on {}. Exception: {}", leaseID, blobWrapper.getStorageUri(), e.getMessage());
         throw(e);
       }
     } finally {


### PR DESCRIPTION
- Including the exception message from 'e' in the log message would provide valuable context for debugging the unanticipated exception.


Created by Patchwork Technologies.