### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/GenerateData.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/GenerateData.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/GenerateData.java
@@ -159,8 +159,7 @@ class GenerateData extends GridmixJob {
     }
 
     // publish the plain data statistics
-    LOG.info("Total size of input data : " 
-             + StringUtils.humanReadableInt(dataSize));
+    LOG.info("Total size of input data in {} : " + StringUtils.humanReadableInt(dataSize), inputDir);
     LOG.info("Total number of input data files : " + fileCount);
     
     return new DataStatistics(dataSize, fileCount, false);


### PR DESCRIPTION
- The log line code should be changed to include 'inputDir' to provide context about the data size being logged.


Created by Patchwork Technologies.