### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/GenerateData.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/GenerateData.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/GenerateData.java
@@ -161,7 +161,7 @@ class GenerateData extends GridmixJob {
     // publish the plain data statistics
     LOG.info("Total size of input data : " 
              + StringUtils.humanReadableInt(dataSize));
-    LOG.info("Total number of input data files : " + fileCount);
+    LOG.info("Total number of input data files in {} : {} ", inputDir, fileCount);
     
     return new DataStatistics(dataSize, fileCount, false);
   }


### PR DESCRIPTION
- The log line code should be changed to include 'inputDir' to add context to the log message, specifying which directory the 'fileCount' is associated with.


Created by Patchwork Technologies.