### PR TITLE
Modifying log contents in hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SimpleKeyProvider.java

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SimpleKeyProvider.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/SimpleKeyProvider.java
@@ -50,7 +50,7 @@ public class SimpleKeyProvider implements KeyProvider {
         key = new String(keyChars);
       }
     } catch(IOException ioe) {
-      LOG.warn("Unable to get key from credential providers.", ioe);
+      LOG.warn("Unable to get key for account {} from credential providers.", accountName, ioe);
     }
     return key;
   }


### PR DESCRIPTION
- The log line code should be changed to include 'accountName' as it would be helpful to identify which storage account's key retrieval failed.


Created by Patchwork Technologies.