### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
@@ -202,7 +202,7 @@ public class Gridmix extends Configured implements Tool {
         LOG.info("Changing the permissions for inputPath {}", inputDir);
         shell.run(new String[] {"-chmod","-R","777", inputDir.toString()});
       } catch (Exception e) {
-        LOG.error("Couldnt change the file permissions " , e);
+        LOG.error("Couldnt change the file permissions for directory {} " , e, inputDir);
         throw new IOException(e);
       }
 


### PR DESCRIPTION
- The log line code should be changed to include 'inputDir' as it provides useful information for debugging the permission change failure.


Created by Patchwork Technologies.