### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
@@ -206,7 +206,7 @@ public class Gridmix extends Configured implements Tool {
         throw new IOException(e);
       }
 
-      LOG.info("Input data generation successful.");
+      LOG.info("Input data generation successful. Generated {} bytes of data in {}.", genbytes, inputDir);
     }
 
     return 0;


### PR DESCRIPTION
- Adding 'genbytes' and 'inputDir' to the log message would provide more context and make it more informative about the successful data generation.


Created by Patchwork Technologies.