### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
@@ -388,7 +388,8 @@ public class Gridmix extends Configured implements Tool {
   private int runJob(Configuration conf, String[] argv)
     throws IOException, InterruptedException {
     if (argv.length < 2) {
-      LOG.error("Too few arguments to Gridmix.\n");
+      LOG.error("Too few arguments to Gridmix: {}.
+", Arrays.toString(argv));
       printUsage(System.err);
       return ARGS_ERROR;
     }


### PR DESCRIPTION
- Adding 'argv' to the log message would make it more informative by showing the actual arguments that caused the error. This would help in understanding why there were too few arguments.


Created by Patchwork Technologies.