### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
@@ -436,7 +436,7 @@ public class Gridmix extends Configured implements Tool {
       ioPath = new Path(argv[argv.length - 2]);
       traceIn = argv[argv.length - 1];
     } catch (Exception e) {
-      LOG.error(e.toString() + "\n");
+      LOG.error("Error encountered while running job with arguments: " + Arrays.toString(argv), e);
       if (LOG.isDebugEnabled()) {
         e.printStackTrace();
       }


### PR DESCRIPTION
- The log line should be updated to include the exception 'e' for the stack trace and 'argv' to show the arguments passed to the method, which could be helpful for debugging. 


Created by Patchwork Technologies.