### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
@@ -456,7 +456,7 @@ public class Gridmix extends Configured implements Tool {
       // No need to emit this exception message
     } finally {
       if (!succeeded) {
-        LOG.error("Failed creation of <ioPath> directory " + ioPath + "\n");
+        LOG.error("Failed creation of <ioPath> directory {} with configuration: {} ", ioPath, conf, e);
         return STARTUP_FAILED_ERROR;
       }
     }


### PR DESCRIPTION
- The log message would be more informative if it included relevant details from the 'conf' and 'argv' parameters, potentially revealing why directory creation failed.


Created by Patchwork Technologies.