### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
@@ -527,7 +527,7 @@ public class Gridmix extends Configured implements Tool {
         factory.start();
         statistics.start();
       } catch (Throwable e) {
-        LOG.error("Startup failed. " + e.toString() + "\n");
+        LOG.error("Startup failed. scratchDir={}, traceIn={}, ioPath={}, userResolver={}.", scratchDir, traceIn, ioPath, userResolver, e);
         LOG.debug("Startup failed", e);
         if (factory != null) factory.abort(); // abort pipeline
         exitCode = STARTUP_FAILED_ERROR;


### PR DESCRIPTION
- Adding 'scratchDir', 'trace', 'traceIn', 'ioPath', and 'userResolver' to the log message would provide more context for debugging startup failures. Other parameters are either already included, irrelevant, or too verbose.


Created by Patchwork Technologies.