### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
@@ -540,7 +540,7 @@ public class Gridmix extends Configured implements Tool {
         factory.join(Long.MAX_VALUE);
         final Throwable badTraceException = factory.error();
         if (null != badTraceException) {
-          LOG.error("Error in trace", badTraceException);
+          LOG.error("Error in trace {}", traceIn, badTraceException);
           throw new IOException("Error in trace", badTraceException);
         }
         // wait for pending tasks to be submitted


### PR DESCRIPTION
- Adding 'traceIn' to the log message would provide valuable context by indicating the source of the problematic trace file. Other parameters are either irrelevant or too verbose for this specific error.


Created by Patchwork Technologies.