### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Gridmix.java
@@ -641,7 +641,7 @@ public class Gridmix extends Configured implements Tool {
       try {
         component.join(maxwait);
       } catch (InterruptedException e) {
-        LOG.warn("Interrupted waiting for " + component);
+        LOG.warn("Interrupted waiting for {} after {} ms", component, maxwait);
       }
 
     }


### PR DESCRIPTION
- Adding 'maxwait' to the log message would provide valuable context about the interruption. Therefore, a code change is needed.


Created by Patchwork Technologies.