### PR TITLE
Modifying log contents in hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/WasbRemoteCallHelper.java

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/WasbRemoteCallHelper.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/WasbRemoteCallHelper.java
@@ -224,7 +224,7 @@ public class WasbRemoteCallHelper {
           String message =
               "Encountered error while making remote call to " + String
                   .join(",", urls) + " retried " + retry + " time(s).";
-          LOG.error(message, ioex);
+          LOG.error("Encountered error while making remote call to {}. Retried {} time(s). Failed URL: {}. Method: {}. Query Parameters: {}.", String.join(",", urls), retry, (httpRequest != null) ? httpRequest.getURI().toString() : urls[index], httpMethod, sanitizeQueryParams(queryParams), ioex);
           throw new WasbRemoteCallException(message, ioex);
         }
       }


### PR DESCRIPTION
- The log message would be more informative if it included the 'retry' count, the specific URL that failed, the 'path', 'queryParams' (sanitizing sensitive data if needed), and the 'httpMethod'. This would provide a clearer picture of the context surrounding the error.


Created by Patchwork Technologies.