### PR TITLE
Modifying log contents in hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/WasbRemoteCallHelper.java

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/WasbRemoteCallHelper.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/WasbRemoteCallHelper.java
@@ -286,7 +286,7 @@ public class WasbRemoteCallHelper {
       Thread.currentThread().interrupt();
       return;
     } catch (Exception e) {
-      LOG.warn("Original exception is ", ioe);
+      LOG.warn("Original exception is {}, retry policy failure exception: {}", ioe, e);
       throw new WasbRemoteCallException(e.getMessage(), e);
     }
     LOG.debug("Not retrying anymore, already retried the urls {} time(s)",


### PR DESCRIPTION
- The log line should include the Exception 'e' to provide more context as to why the original Exception was not handled correctly by the retry policy.


Created by Patchwork Technologies.