### PR TITLE
Modifying log contents in hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/security/JsonUtils.java

### DIFF
--- a/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/security/JsonUtils.java
+++ b/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azure/security/JsonUtils.java
@@ -43,8 +43,7 @@ public final class JsonUtils {
       LOG.debug("JSON Parsing exception: {} while parsing {}", e.getMessage(),
           jsonString);
       if (jsonString.toLowerCase(Locale.ENGLISH).contains("server error")) {
-        LOG.error(
-            "Internal Server Error was encountered while making a request");
+        LOG.error("Internal Server Error was encountered while making a request. Exception: {}. JSON: {}", e.getMessage(), jsonString);
       }
       throw new IOException("JSON Parsing Error: " + e.getMessage(), e);
     }


### PR DESCRIPTION
- The log message should be improved to provide more context. Specifically, it should include the relevant error message from the exception and the JSON string that caused the parsing issue. This additional information will be invaluable for debugging.


Created by Patchwork Technologies.