### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobMonitor.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobMonitor.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobMonitor.java
@@ -206,7 +206,7 @@ class JobMonitor implements Gridmix.Component<JobStats> {
                 synchronized (mJobs) {
                   if (!mJobs.offer(jobStats)) {
                     LOG.error("Lost job " + (null == job.getJobName()
-                         ? "<unknown>" : job.getJobName())); // should never
+                         ? "<unknown>" : job.getJobName()) + ", status: " + status + ", jobStats: " + jobStats); // should never// should never
                                                              // happen
                   }
                 }


### PR DESCRIPTION
- The log line code should be changed to include 'status' and 'jobStats' as they may provide useful debugging information in the event of a job being lost.


Created by Patchwork Technologies.