### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobMonitor.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobMonitor.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobMonitor.java
@@ -221,7 +221,7 @@ class JobMonitor implements Gridmix.Component<JobStats> {
                 Thread.currentThread().interrupt();
               } else {
                 LOG.warn("Lost job " + (null == job.getJobName()
-                     ? "<unknown>" : job.getJobName()), e);
+                     ? "<unknown>" : job.getJobName()) + ", jobStats: " + jobStats, e);
                 synchronized (statistics) {
                   statistics.add(jobStats);
                 }


### PR DESCRIPTION
- The log line code should be changed to include 'jobStats' as it contains valuable debugging information about the job.


Created by Patchwork Technologies.