### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobSubmitter.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobSubmitter.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobSubmitter.java
@@ -94,7 +94,7 @@ class JobSubmitter implements Gridmix.Component<GridmixJob> {
                    + job.getJob().getJobID() + ": " + (end - start) + " ms.");
         } catch (IOException e) {
           LOG.warn("Failed to submit " + job.getJob().getJobName() + " as " 
-                   + job.getUgi(), e);
+                   + job.getUgi() + " Job stats: " + stats, e);
           monitor.submissionFailed(stats);
           return;
         } catch (Exception e) {


### PR DESCRIPTION
- The log line code should be changed to include 'stats' as it would provide valuable job specific information for debugging job submission failures.


Created by Patchwork Technologies.