### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobSubmitter.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobSubmitter.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobSubmitter.java
@@ -99,7 +99,7 @@ class JobSubmitter implements Gridmix.Component<GridmixJob> {
           return;
         } catch (Exception e) {
           LOG.warn("Failed to submit " + job.getJob().getJobName() + " as " 
-                   + job.getUgi(), e);
+                   + job.getUgi() + ", stats=" + stats, e);
           monitor.submissionFailed(stats);
           return;
         }


### PR DESCRIPTION
- The log line code should be changed to include 'stats' as it would provide valuable debugging information in case of job submission failures.


Created by Patchwork Technologies.