### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobSubmitter.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobSubmitter.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobSubmitter.java
@@ -135,7 +135,7 @@ class JobSubmitter implements Gridmix.Component<GridmixJob> {
           }
         } catch (IOException e) {
           LOG.warn("Failed to submit " + job.getJob().getJobName() + " as " 
-                   + job.getUgi(), e);
+                   + job.getUgi() + ", stats=" + stats, e);
           if (e.getCause() instanceof ClosedByInterruptException) {
             throw new InterruptedException("Failed to submit " +
                 job.getJob().getJobName());


### PR DESCRIPTION
- The log line code should be changed to include 'stats' as it would provide valuable debugging information for job submission failures.


Created by Patchwork Technologies.