### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobSubmitter.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobSubmitter.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobSubmitter.java
@@ -142,7 +142,7 @@ class JobSubmitter implements Gridmix.Component<GridmixJob> {
           }
           monitor.submissionFailed(stats);
         } catch (ClassNotFoundException e) {
-          LOG.warn("Failed to submit " + job.getJob().getJobName(), e);
+          LOG.warn("Failed to submit " + job.getJob().getJobName() + " " + stats, e);
           monitor.submissionFailed(stats);
         }
       } catch (InterruptedException e) {


### PR DESCRIPTION
- The log line code should be changed to include 'stats' which provides more context about the job that failed to submit.


Created by Patchwork Technologies.