### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobSubmitter.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobSubmitter.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/JobSubmitter.java
@@ -153,7 +153,7 @@ class JobSubmitter implements Gridmix.Component<GridmixJob> {
         monitor.submissionFailed(stats);
       } catch(Exception e) {
         //Due to some exception job wasnt submitted.
-        LOG.info(" Job " + job.getJob().getJobID() + " submission failed " , e);
+        LOG.info("Job " + job.getJob().getJobID() + " submission failed. Job stats: " + stats, e);
         monitor.submissionFailed(stats);
       } finally {
         sem.release();


### PR DESCRIPTION
- The log level is already correct as INFO since the job submission failing might not be an error, but we should include the stacktrace of the exception and the job stats to help determine the cause.


Created by Patchwork Technologies.