### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/LoadJob.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/LoadJob.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/LoadJob.java
@@ -470,7 +470,7 @@ class LoadJob extends GridmixJob {
         }
       }
       if (0 == outRecords && inRecords > 0) {
-        LOG.info("Spec output bytes w/o records. Using input record count");
+              LOG.info("Spec output bytes w/o records: {}. Using input record count", outBytes);
         outRecords = inRecords;
       }
       


### PR DESCRIPTION
- Adding 'outBytes' and its value to the log message would provide better context and help understand the situation when output records are derived from input records. 


Created by Patchwork Technologies.