### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/ReplayJobFactory.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/ReplayJobFactory.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/ReplayJobFactory.java
@@ -93,7 +93,7 @@ import java.util.concurrent.TimeUnit;
             }
             final long current = job.getSubmissionTime();
             if (current < last) {
-              LOG.warn("Job " + job.getJobID() + " out of order");
+              LOG.warn("Job " + job.getJobID() + " out of order (current: " + current + ", last: " + last + ", first: " + first + ")");
               continue;
             }
             last = current;


### PR DESCRIPTION
- Adding 'current', 'first', and 'last' to the log message would provide more context about the order of job submissions, making it easier to debug the issue.


Created by Patchwork Technologies.