### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/RoundRobinUserResolver.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/RoundRobinUserResolver.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/RoundRobinUserResolver.java
@@ -85,7 +85,7 @@ public class RoundRobinUserResolver implements UserResolver {
           ugi = UserGroupInformation.createProxyUser(username,
                     UserGroupInformation.getLoginUser());
         } catch (IOException ioe) {
-          LOG.error("Error while creating a proxy user " ,ioe);
+          LOG.error("Error while creating a proxy user for username: {} using userloc: {} and rawUgi: {}", username, userloc, rawUgi, ioe);
         }
         if (ugi != null) {
           ugiList.add(ugi);


### PR DESCRIPTION
- Adding 'username', 'userloc', and 'rawUgi' to the log message would provide valuable context for debugging proxy user creation failures. 


Created by Patchwork Technologies.