### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/SerialJobFactory.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/SerialJobFactory.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/SerialJobFactory.java
@@ -124,9 +124,7 @@ public class SerialJobFactory extends JobFactory<JobStats> {
                 try {
                   jobCompleted.await();
                 } catch (InterruptedException ie) {
-                  LOG.error(
-                    " Error in SerialJobFactory while waiting for job completion ",
-                    ie);
+                  LOG.error(" Error in SerialJobFactory while waiting for job completion for job: " + job.getName(), ie);
                   return;
                 }
                 if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
- The log line code should be changed to include 'job' to provide context about which job failed to complete.


Created by Patchwork Technologies.