### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/SleepJob.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/SleepJob.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/SleepJob.java
@@ -264,7 +264,7 @@ public class SleepJob extends GridmixJob {
         @Override
         public void close() throws IOException {
           final String msg = "Slept for " + duration;
-          LOG.info(msg);
+          LOG.info("Slept for {} ms (duration {}), with sleep interval {} ms (RINTERVAL {} ms)", slept, duration, sleepInterval, RINTERVAL);
         }
 
         public void initialize(InputSplit split, TaskAttemptContext ctxt) {


### PR DESCRIPTION
- Adding 'duration', 'sleepInterval', and 'RINTERVAL' to the log message would provide more detailed information about the sleep behavior, aiding in analysis and debugging.


Created by Patchwork Technologies.