### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Statistics.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Statistics.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/Statistics.java
@@ -166,8 +166,7 @@ public class Statistics implements Component<Statistics.JobStats> {
     
     // stat cannot be null
     if (stat == null) {
-      LOG.error("[Statistics] Missing entry for job " 
-                + job.getJob().getJobID());
+      LOG.error(" [Statistics] Missing entry for job " + job.getJob().getJobID() + " with stat: " + stat + ". stat object contains: numMaps=" + stat.getNoOfMaps() + ", numReduces=" + stat.getNoOfReds());
       return;
     }
     


### PR DESCRIPTION
- The log line should include more information from the 'stat' object, as it would be helpful to know what information is missing. 


Created by Patchwork Technologies.