### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/StressJobFactory.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/StressJobFactory.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/StressJobFactory.java
@@ -272,7 +272,7 @@ public class StressJobFactory extends JobFactory<Statistics.ClusterStats> {
         (int) (maxJobTrackerRatio * numTrackers) - item.getNumRunningJob();
       loadStatus.updateJobLoad(jobLoad);
     } catch (Exception e) {
-      LOG.error("Couldn't get the new Status",e);
+      LOG.error("Couldn't get the new Status. Details: maxMapTasks={}, maxReduceTasks={}, taskTrackers={}", clusterStatus.getMaxMapTasks(), clusterStatus.getMaxReduceTasks(), clusterStatus.getTaskTrackers(), e);
     }
   }
 


### PR DESCRIPTION
- The log message would be more informative if it included specific details from 'clusterStatus' that are relevant to the error. This would help in understanding why obtaining the new status failed.


Created by Patchwork Technologies.