### PR TITLE
Modifying log contents in hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/StressJobFactory.java

### DIFF
--- a/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/StressJobFactory.java
+++ b/hadoop-tools/hadoop-gridmix/src/main/java/org/apache/hadoop/mapred/gridmix/StressJobFactory.java
@@ -426,7 +426,7 @@ public class StressJobFactory extends JobFactory<Statistics.ClusterStats> {
             break;
           }
         } else {
-          LOG.warn("Blacklisting empty job: " + id);
+          LOG.warn("Blacklisting empty job: " + id + " noOfMaps: " + noOfMaps + " noOfReduces: " + noOfReduces);
           blacklistedJobs.add(id);
         }
       }


### PR DESCRIPTION
- Including noOfMaps and noOfReduces would provide more context as to why the job is considered empty. 


Created by Patchwork Technologies.