### PR TITLE
Modifying log contents in hadoop-tools/hadoop-resourceestimator/src/main/java/org/apache/hadoop/resourceestimator/service/ResourceEstimatorServer.java

### DIFF
--- a/hadoop-tools/hadoop-resourceestimator/src/main/java/org/apache/hadoop/resourceestimator/service/ResourceEstimatorServer.java
+++ b/hadoop-tools/hadoop-resourceestimator/src/main/java/org/apache/hadoop/resourceestimator/service/ResourceEstimatorServer.java
@@ -121,7 +121,7 @@ public final class ResourceEstimatorServer extends CompositeService {
       resourceEstimatorServer.init(config);
       resourceEstimatorServer.start();
     } catch (Throwable t) {
-      LOGGER.error("Error starting ResourceEstimatorServer", t);
+      LOGGER.error("Error starting ResourceEstimatorServer with config: {}", config, t);
     }
 
     return resourceEstimatorServer;


### PR DESCRIPTION
- The log line code should be changed to include 'config' as it may be useful for debugging to know what configuration was used to start the ResourceEstimatorServer.


Created by Patchwork Technologies.